### PR TITLE
Update hprt.android.ts

### DIFF
--- a/src/hprt.android.ts
+++ b/src/hprt.android.ts
@@ -73,7 +73,7 @@ export class Hprt {
     }
 
     isBluetoothEnabled(): boolean {
-        return this.mBluetoothAdapter.isEnabled() && this.mBluetoothAdapter != null ? true : false;
+        return this.mBluetoothAdapter != null && this.mBluetoothAdapter.isEnabled()  ? true : false;
     }
 
     isBluetoothEnabledPromise(): Promise<any> {


### PR DESCRIPTION
First it should check if mBluetoothAdapter is not null then only it should access property of isEnabled() method of mBluetoothAdapter object.

Its causing me an error in emulator.